### PR TITLE
Kill the jaspar service with SIGINT

### DIFF
--- a/meta-jaspar/recipes-jaspar/jaspar/jaspar.service
+++ b/meta-jaspar/recipes-jaspar/jaspar/jaspar.service
@@ -9,6 +9,7 @@ ExecStart=/usr/share/jaspar/ivi-connection-manager/ivi_connection_manager.py
 Environment="HOME=/home/root"
 Environment="DISPLAY=:0.0"
 TimeoutStopSec=10s
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows a clean shutdown (SIGINT is like ctrl-c)
