### PR TITLE
Start matchbox-desktop from jaspar.service

### DIFF
--- a/meta-jaspar/recipes-jaspar/matchbox-sato/matchbox-session-sato/session
+++ b/meta-jaspar/recipes-jaspar/matchbox-sato/matchbox-session-sato/session
@@ -21,5 +21,5 @@ echo `/usr/share/jaspar/monitor.py`
   sleep 1;
 done | dzen2 -h 108 -fg white -bg black -fn Sans -dock &
 
-matchbox-window-manager -use_titlebar no -theme Sato -use_cursor $SHOWCURSOR &
-exec matchbox-desktop
+# matchbox-desktop is started by jaspar.service
+exec matchbox-window-manager -use_titlebar no -theme Sato -use_cursor $SHOWCURSOR

--- a/meta-jaspar/recipes-jaspar/matchbox-sato/matchbox-session-sato_0.1.bb
+++ b/meta-jaspar/recipes-jaspar/matchbox-sato/matchbox-session-sato_0.1.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://session;endline=1;md5=3e2b31c72181b87149ff995e7202c0e
 SECTION = "x11"
 DEPENDS = "gconf-native"
 RDEPENDS_${PN} = "formfactor gtk-sato-engine matchbox-theme-sato gtk-theme-sato matchbox-panel-2 matchbox-desktop-sato matchbox-session gconf"
-PR = "r36"
+PR = "r37"
 PV = "0.4"
 
 # This package is architecture specific because the session script is modified


### PR DESCRIPTION
We are already starting it from the python jaspar service, this change just
stops starting it twice
