### PR TITLE
Add tcpdump and usb tracing support

### DIFF
--- a/meta-jaspar/recipes-jaspar/jaspar-image/jaspar-image.bb
+++ b/meta-jaspar/recipes-jaspar/jaspar-image/jaspar-image.bb
@@ -19,4 +19,5 @@ IMAGE_INSTALL += " \
 	epiphany jaspar wds \
 	gmediarender gupnp-tools \
 	matchbox-wm matchbox-panel-2 \
+	tcpdump \
 	"

--- a/meta-jaspar/recipes-jaspar/linux-yocto/linux-yocto_4.1.bbappend
+++ b/meta-jaspar/recipes-jaspar/linux-yocto/linux-yocto_4.1.bbappend
@@ -6,6 +6,7 @@ SRC_URI += "\
 	file://bt.cfg \
 	file://tether.cfg \
 	file://touchscreen.cfg \
+	file://usbmon.cfg \
 	"
 LINUX_VERSION_EXTENSION = "-ats"
 

--- a/meta-jaspar/recipes-jaspar/linux-yocto/usbmon.cfg
+++ b/meta-jaspar/recipes-jaspar/linux-yocto/usbmon.cfg
@@ -1,0 +1,1 @@
+CONFIG_USB_MON=y


### PR DESCRIPTION
This can be used to capture a trace of the usb traffic (which can be later
analysed in wireshark) using:

  tcpdump -i usbmon0 -w usb-packet-dump.pcap
