### PR TITLE
Add repo manifest to build

### DIFF
--- a/classes/image-repo-manifest.bbclass
+++ b/classes/image-repo-manifest.bbclass
@@ -1,0 +1,17 @@
+# Writes the repo manifest to the target filesystem in /etc/manifest.xml
+#
+# Author: Phil Wise <phil@advancedtelematic.com>
+# Usage: add "inherit image-repo-manifest" to your image file
+# To reproduce a build, copy the /etc/manifest.xml to .repo/manifests/yourname.xml
+# then run:
+# repo init -m yourname.xml
+# repo sync
+# See https://wiki.cyanogenmod.org/w/Doc:_Using_manifests for more information
+
+# Write build information to target filesystem
+buildinfo () {
+  repo manifest --revision-as-HEAD -o ${IMAGE_ROOTFS}${sysconfdir}/manifest.xml
+}
+
+
+IMAGE_PREPROCESS_COMMAND += "buildinfo;"

--- a/recipes-oim/openivi-image/openivi-image.bb
+++ b/recipes-oim/openivi-image/openivi-image.bb
@@ -5,6 +5,7 @@ IMAGE_FEATURES += "splash package-management x11-base x11-sato ssh-server-dropbe
 LICENSE = "MIT"
 
 inherit core-image
+inherit image-repo-manifest
 
 APPEND+="console=ttyS0,115200 quiet"
 


### PR DESCRIPTION
This allows someone who receives a built image to exactly reproduce the build.
