### PR TITLE
Moved DISTRO_FEATURES to local.conf.sample, didn't work in image recipe

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -91,6 +91,12 @@ DISTRO ?= "poky"
 # useful to most new users.
 # DISTRO ?= "poky-bleeding"
 
+# Additional distro features
+DISTRO_FEATURES_append = " x11 systemd "
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+
+VIRTUAL-RUNTIME_init_manager = "systemd"
+
 #
 # Package Management configuration
 #

--- a/recipes-oim/openivi-image/openivi-image.bb
+++ b/recipes-oim/openivi-image/openivi-image.bb
@@ -24,7 +24,3 @@ IMAGE_INSTALL_append = " \
 	xinput \
 	"
 
-DISTRO_FEATURES_append = " x11 systemd "
-DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
-VIRTUAL-RUNTIME_init_manager = "systemd"
-


### PR DESCRIPTION
Not sure about VIRTUAL_RUNTIME, it may still work in image recipe, but moving to "conf" would do no harm either.
