### PR TITLE
Add sota-system-info to /usr/bin

### DIFF
--- a/recipes-oim/jq/jq_1.5.bb
+++ b/recipes-oim/jq/jq_1.5.bb
@@ -1,0 +1,26 @@
+# From meta-oe
+# git://git.openembedded.org/meta-openembedded
+
+SUMMARY = "Lightweight and flexible command-line JSON processor"
+DESCRIPTION = "jq is like sed for JSON data, you can use it to slice and \
+               filter and map and transform structured data with the same \
+               ease that sed, awk, grep and friends let you play with text."
+HOMEPAGE = "http://stedolan.github.io/jq/"
+BUGTRACKER = "https://github.com/stedolan/jq/issues"
+SECTION = "utils"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=29dd0c35d7e391bb8d515eacf7592e00"
+
+DEPENDS = "flex-native bison-native onig"
+
+SRC_URI = "https://github.com/stedolan/${BPN}/releases/download/${BPN}-${PV}/${BPN}-${PV}.tar.gz \
+"
+
+SRC_URI[md5sum] = "0933532b086bd8b6a41c1b162b1731f9"
+SRC_URI[sha256sum] = "c4d2bfec6436341113419debf479d833692cc5cdab7eb0326b5a4d4fbe9f493c"
+
+inherit autotools
+
+# Don't build documentation (generation requires ruby)
+EXTRA_OECONF = "--disable-docs --disable-maintainer-mode"

--- a/recipes-oim/onig/files/configure.patch
+++ b/recipes-oim/onig/files/configure.patch
@@ -1,0 +1,13 @@
+Index: onig-5.9.3/configure.in
+===================================================================
+--- onig-5.9.3.orig/configure.in	2012-10-26 07:06:14.000000000 +0000
++++ onig-5.9.3/configure.in	2014-07-18 08:02:52.701574484 +0000
+@@ -3,7 +3,7 @@
+ 
+ AC_CONFIG_MACRO_DIR([m4])
+ 
+-AM_INIT_AUTOMAKE
++AM_INIT_AUTOMAKE([foreign])
+ AC_CONFIG_HEADER(config.h)
+ 
+ 

--- a/recipes-oim/onig/files/do-not-use-system-headers.patch
+++ b/recipes-oim/onig/files/do-not-use-system-headers.patch
@@ -1,0 +1,44 @@
+Author: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+
+When build on host with older eglibc (Ubuntu 12.04) build fails with:
+
+/tmp/OE/build/tmp-eglibc/sysroots/genericarmv8/usr/include/bits/predefs.h:23:3: error: #error "Never use <bits/predefs.h> directly; include <stdc-predef.h> instead."
+
+Signed-off-by: Marcin Juszkiewicz <marcin.juszkiewicz@linaro.org>
+
+Upstream-Status: Inappropriate [embedded specific]
+
+---
+ Makefile.am        |    2 +-
+ sample/Makefile.am |    2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+--- onig-5.9.3.orig/Makefile.am
++++ onig-5.9.3/Makefile.am
+@@ -4,11 +4,11 @@ sampledir = $(top_srcdir)/sample
+ libname = libonig.la
+
+ ACLOCAL_AMFLAGS = -I m4
+ #AM_CFLAGS = -DNOT_RUBY
+ AM_CFLAGS =
+-INCLUDES  = -I$(top_srcdir) -I$(includedir)
++INCLUDES  = -I$(top_srcdir)
+
+ SUBDIRS = . sample
+
+ include_HEADERS = oniguruma.h oniggnu.h onigposix.h
+ lib_LTLIBRARIES = $(libname)
+--- onig-5.9.3.orig/sample/Makefile.am
++++ onig-5.9.3/sample/Makefile.am
+@@ -1,10 +1,10 @@
+ noinst_PROGRAMS = encode listcap names posix simple sql syntax crnl
+
+ libname = $(top_builddir)/libonig.la
+ LDADD   = $(libname)
+-INCLUDES  = -I$(top_srcdir) -I$(includedir)
++INCLUDES  = -I$(top_srcdir)
+
+ encode_SOURCES  = encode.c
+ listcap_SOURCES = listcap.c
+ names_SOURCES   = names.c
+ posix_SOURCES   = posix.c

--- a/recipes-oim/onig/onig_5.9.3.bb
+++ b/recipes-oim/onig/onig_5.9.3.bb
@@ -1,0 +1,20 @@
+# From meta-oe
+# git://git.openembedded.org/meta-openembedded
+
+DESCRIPTION = "Regular expressions library. The characteristics of this \
+library is that different character encoding for every regular expression \
+object can be specified."
+HOMEPAGE = "http://www.geocities.jp/kosako3/oniguruma/"
+LICENSE = "BSD"
+LIC_FILES_CHKSUM = "file://COPYING;md5=0d4861b5bc0c392a5aa90d9d76ebd86f"
+
+SRC_URI = "http://www.geocities.jp/kosako3/oniguruma/archive/onig-${PV}.tar.gz \
+           file://do-not-use-system-headers.patch \
+           file://configure.patch"
+
+SRC_URI[md5sum] = "0d4eda2066d3c92970842a6790ce897a"
+SRC_URI[sha256sum] = "c3bba66b2a84760e6582c40881db97c839d94f327870009724bb8b4d0c051f2a"
+
+DEPENDS = "libevent"
+
+inherit autotools binconfig

--- a/recipes-oim/openivi-image/openivi-image.bb
+++ b/recipes-oim/openivi-image/openivi-image.bb
@@ -22,5 +22,4 @@ IMAGE_INSTALL_append = " \
 	ota-plus-demo-provision \
 	sota-client \
 	xinput \
-	lshw \
 	"

--- a/recipes-oim/sota-client/sota-client.bb
+++ b/recipes-oim/sota-client/sota-client.bb
@@ -14,6 +14,7 @@ BBCLASSEXTEND = "native"
 
 FILES_${PN} = " \
                 /usr/bin/sota_client \
+                /usr/bin/sota-system-info \
                 /etc/sota_client.version \
                 ${base_libdir}/systemd/system/sota_client.service \
               "
@@ -21,11 +22,18 @@ FILES_${PN} = " \
 SYSTEMD_SERVICE_${PN} = "sota_client.service"
 
 DEPENDS += " openssl "
-RDEPENDS_${PN} = " libcrypto libssl dbus "
+RDEPENDS_${PN} = " libcrypto \
+                   libssl \
+                   dbus \
+                   bash \
+                   lshw \
+                   jq \
+                   "
 
 do_install() {
   install -d ${D}${bindir}
   install -m 0755 target/x86_64-poky-linux/release/sota_client ${D}${bindir}
+  install -m 0755 run/sota-system-info ${D}${bindir}
 
   install -d ${D}${systemd_unitdir}/system
   install -c ${S}/run/sota_client.service ${D}${systemd_unitdir}/system


### PR DESCRIPTION
[PRO-1007]

Add the sota-system-info script from rvi_sota_client. sota-system-info requires Jq, which is copied from meta-oe.
