### PR TITLE
Feat/extra space pro 1159

### DIFF
--- a/recipes-oim/openivi-image/openivi-image.bb
+++ b/recipes-oim/openivi-image/openivi-image.bb
@@ -9,6 +9,15 @@ inherit image-repo-manifest
 
 APPEND+="console=ttyS0,115200 quiet"
 
+# We don't support/test the ISO image, so don't build it
+NOISO = "1"
+
+# In 512 byte blocks
+BOOTIMG_EXTRA_SPACE = "2000000"
+
+# In kb
+IMAGE_ROOTFS_EXTRA_SPACE = "100000"
+
 IMAGE_INSTALL_append = " \
 	kernel-modules \
 	linux-firmware \

--- a/scripts/mkefidisk.sh
+++ b/scripts/mkefidisk.sh
@@ -445,7 +445,7 @@ else
     set openivi present
 endif
 bcfg boot add 0 fs0:\\EFI\\BOOT\\bootx64.efi OpenIVI
-fs0:\EFI\BOOT\bootx64.efi" > $EFIDIR/startup.nsh
+fs0:\\EFI\\BOOT\\bootx64.efi" > $EFIDIR/startup.nsh
 
 # Call cleanup to unmount devices and images and remove the TMPDIR
 cleanup


### PR DESCRIPTION
root@genericx86-64:~# df -h
Filesystem                Size      Used Available Use% Mounted on
none                    940.4M      4.0K    940.4M   0% /dev
/dev/mmcblk0              2.7G    760.3M      1.9G  28% /media/realroot
/dev/loop0              683.7M    460.3M    171.2M  73% /
tmpfs                   944.8M     72.0K    944.8M   0% /dev/shm
tmpfs                   944.8M      9.4M    935.4M   1% /run
tmpfs                   944.8M         0    944.8M   0% /sys/fs/cgroup
tmpfs                   944.8M      8.0K    944.8M   0% /tmp
tmpfs                   944.8M     24.0K    944.8M   0% /var/volatile
