### PR TITLE
Update sota_client recipe to match Cargo.toml

### DIFF
--- a/recipes-oim/sota-client/sota-client.bb
+++ b/recipes-oim/sota-client/sota-client.bb
@@ -10,9 +10,8 @@ inherit cargo systemd
 
 S = "${WORKDIR}/git"
 
-SRCREV = "484e98981f5ddbf61a9e4ca6190c9f2c2fcdec4c"
-PV = "0.2.17.5.g484e989"
-PR = "${SRCPV}"
+SRCREV = "20d9ebb51b3bcace6558eabda71a078df97a4e48"
+PV = "0.2.19+20d9eb"
 
 BBCLASSEXTEND = "native"
 
@@ -25,80 +24,78 @@ FILES_${PN} = " \
               "
 
 SRC_URI = " \
-crate://crates.io/aho-corasick/0.5.2 \
+crate://crates.io/aho-corasick/0.5.3 \
 crate://crates.io/time/0.1.35 \
-crate://crates.io/url/1.1.1 \
+crate://crates.io/url/1.2.1 \
 crate://crates.io/ws2_32-sys/0.2.1 \
 crate://crates.io/hyper/0.9.4 \
 crate://crates.io/log/0.3.6 \
 crate://crates.io/unicase/1.4.0 \
-crate://crates.io/bitflags/0.5.0 \
+crate://crates.io/bitflags/0.7.0 \
 crate://crates.io/bit-set/0.2.0 \
-crate://crates.io/lazy_static/0.1.16 \
+crate://crates.io/lazy_static/0.2.1 \
 crate://crates.io/rust-crypto/0.2.36 \
 crate://crates.io/typeable/0.1.2 \
 crate://crates.io/pkg-config/0.3.8 \
 crate://crates.io/httparse/1.1.2 \
-crate://crates.io/openssl/0.7.13 \
+crate://crates.io/openssl/0.8.3 \
 crate://crates.io/user32-sys/0.2.0 \
-crate://crates.io/regex/0.1.71 \
+crate://crates.io/regex/0.1.77 \
 crate://crates.io/unicode-normalization/0.1.2 \
 crate://crates.io/idna/0.1.0 \
 crate://crates.io/unicode-bidi/0.2.3 \
 crate://crates.io/rand/0.3.14 \
-crate://crates.io/gcc/0.3.28 \
+crate://crates.io/gcc/0.3.37 \
 crate://crates.io/chan/0.1.18 \
 crate://crates.io/kernel32-sys/0.2.2 \
-crate://crates.io/winapi/0.2.7 \
-crate://crates.io/crossbeam/0.2.9 \
+crate://crates.io/winapi/0.2.8 \
+crate://crates.io/crossbeam/0.2.10 \
 crate://crates.io/bitflags/0.4.0 \
 crate://crates.io/thread-id/2.0.0 \
-crate://crates.io/mime/0.2.1 \
-crate://crates.io/thread_local/0.2.6 \
+crate://crates.io/mime/0.2.2 \
+crate://crates.io/thread_local/0.2.7 \
 crate://crates.io/utf8-ranges/0.1.3 \
-crate://crates.io/net2/0.2.23 \
-crate://crates.io/dbus/0.3.3 \
+crate://crates.io/net2/0.2.26 \
+crate://crates.io/dbus/0.4.1 \
 crate://crates.io/winapi-build/0.1.1 \
-crate://crates.io/chan-signal/0.1.6 \
+crate://crates.io/chan-signal/0.1.7 \
 crate://crates.io/bit-vec/0.4.3 \
-crate://crates.io/toml/0.1.30 \
+crate://crates.io/toml/0.2.1 \
 crate://crates.io/quick-error/0.2.2 \
-crate://crates.io/ws/0.5.0 \
+crate://crates.io/ws/0.5.3 \
 crate://crates.io/traitobject/0.0.1 \
 crate://crates.io/cfg-if/0.1.0 \
-crate://crates.io/matches/0.1.2 \
+crate://crates.io/matches/0.1.3 \
 crate://crates.io/getopts/0.2.14 \
-crate://crates.io/sha1/0.1.1 \
-crate://crates.io/openssl-sys/0.7.13 \
+crate://crates.io/sha1/0.2.0 \
+crate://crates.io/openssl-sys/0.7.17 \
 crate://crates.io/cookie/0.2.5 \
 crate://crates.io/libressl-pnacl-sys/2.1.6 \
-crate://crates.io/lazy_static/0.2.1 \
 crate://crates.io/language-tags/0.2.2 \
 crate://crates.io/semver/0.1.20 \
 crate://crates.io/unix_socket/0.5.0 \
 crate://crates.io/memchr/0.1.11 \
 crate://crates.io/gdi32-sys/0.2.0 \
-crate://crates.io/nom/1.2.3 \
+crate://crates.io/nom/1.2.4 \
 crate://crates.io/mio/0.5.1 \
-crate://crates.io/tempdir/0.3.4 \
-crate://crates.io/miow/0.1.2 \
+crate://crates.io/tempdir/0.3.5 \
+crate://crates.io/miow/0.1.3 \
 crate://crates.io/pnacl-build-helper/1.4.10 \
-crate://crates.io/libc/0.2.12 \
+crate://crates.io/libc/0.2.17 \
 crate://crates.io/nix/0.5.1 \
-crate://crates.io/byteorder/0.5.3 \
 crate://crates.io/rustc_version/0.1.7 \
 crate://crates.io/slab/0.1.3 \
 crate://crates.io/rustc-serialize/0.3.19 \
-crate://crates.io/env_logger/0.3.3 \
+crate://crates.io/env_logger/0.3.5 \
 crate://crates.io/vecio/0.1.0 \
 crate://crates.io/rotor/0.6.3 \
-crate://crates.io/openssl-sys-extras/0.7.13 \
-crate://crates.io/regex-syntax/0.3.3 \
+crate://crates.io/openssl-sys-extras/0.7.14 \
+crate://crates.io/regex-syntax/0.3.7 \
 crate://crates.io/bytes/0.3.0 \
 crate://crates.io/void/1.0.2 \
 crate://crates.io/spmc/0.2.1 \
 crate://crates.io/openssl-verify/0.1.0 \
-crate-index://crates.io/6127fc24b0b6fe73fe4d339817fbf000b9a798a2 \
+crate-index://crates.io/7670a5aa394d0dcd7598905b352d1634ca74d84a \
 git://github.com/advancedtelematic/rvi_sota_client \
 "
 SRC_URI[index.md5sum] = "79f10f436dbf26737cc80445746f16b4"
@@ -114,6 +111,15 @@ RDEPENDS_${PN} = " libcrypto \
                    lshw \
                    jq \
                    "
+do_compile_prepend() {
+  # See PRO-1659
+  make rust-openssl
+}
+
+do_compile_append() {
+  # See PRO-1659
+  strings target/${TARGET_SYS}/release/sota_client | grep ${EXTENDPE}${PV}-${PR}/git/rust-openssl -q || (bberror "local rust-open ssl package not used"; exit 1)
+}
 
 do_install() {
   install -d ${D}${bindir}


### PR DESCRIPTION
This fixes:
PRO-1713 - OpenIVI fails to build
PRO-1659 - Remove manual steps from the build process
