### PR TITLE
Disable the udev automounter to fix race condition

### DIFF
--- a/recipes-oim/provision/udev-extraconf_%.bbappend
+++ b/recipes-oim/provision/udev-extraconf_%.bbappend
@@ -1,0 +1,5 @@
+# udev-extraconf creates output in /etc rather than /usr/lib/udev, so we can't
+# easily override them. Instead bbappend and delete the rule
+do_install_append() {
+    rm ${D}${sysconfdir}/udev/rules.d/automount.rules
+}


### PR DESCRIPTION
The udev automounter was grabbing the device and mounting it in its private
container (systemd does that). Disable the udev automounter with a .bbappend.