### PR TITLE
dzen2: Fix config.mk and use Xft

### DIFF
--- a/meta-jaspar/recipes-jaspar/dzen2/files/0001-Update-build-configurations.patch
+++ b/meta-jaspar/recipes-jaspar/dzen2/files/0001-Update-build-configurations.patch
@@ -1,6 +1,6 @@
-From 77fefc54c2d1d5d86df53624046bec8757d83648 Mon Sep 17 00:00:00 2001
+From a01ab908063c00e7e41785081416c3b3f96ec681 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
-Date: Mon, 27 Mar 2017 19:26:56 +0300
+Date: Tue, 28 Mar 2017 19:10:28 +0300
 Subject: [PATCH] Update build configurations
 
 Update configurations in config.mk and Makefile
@@ -82,7 +82,7 @@ index 478d6f0..8d6b396 100644
  uninstall:
  	@echo removing executable file from ${DESTDIR}${PREFIX}/bin
 diff --git a/config.mk b/config.mk
-index 311f785..1f94526 100644
+index 311f785..75279ce 100644
 --- a/config.mk
 +++ b/config.mk
 @@ -1,63 +1,38 @@
@@ -100,7 +100,7 @@ index 311f785..1f94526 100644
  X11INC = /usr/X11R6/include
  X11LIB = /usr/X11R6/lib
 -INCS = -I. -I/usr/include -I${X11INC}
-+INCS = -I.
++INCS = -DDZEN_XFT -I. `pkg-config --cflags xft`
  
  # Configure the features you want to be supported
 -# Only one of the following options has to be uncommented,
@@ -114,7 +114,7 @@ index 311f785..1f94526 100644
 -#LIBS = -L/usr/lib -lc -L${X11LIB} -lX11
 -#CFLAGS = -Wall -Os ${INCS} -DVERSION=\"${VERSION}\"
 +# Option 1: No Xinerama no XPM
-+LIBS = -lc -lX11
++LIBS = -lc -lX11 `pkg-config --libs xft`
 +CFLAGS = -Os ${INCS} -DVERSION=\"${VERSION}\"
  
 -


### PR DESCRIPTION
Update configurations to use Xft, the X FreeType
interface library, and fix compatibility with
the way Python scripts in jaspar set fonts for
dzen2.

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>